### PR TITLE
docker-compose upでrails serverを起動できるように編集

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,6 @@ FROM ruby:3.2.2
 RUN apt-get update -qq && apt-get install -y build-essential libpq-dev nodejs
 RUN mkdir /rails-docker
 WORKDIR /rails-docker
-ADD Gemfile /rails-docker/Gemfile
-ADD Gemfile.lock /rails-docker/Gemfile.lock
+COPY Gemfile Gemfile.lock /rails-docker/
 RUN bundle install
 ADD . /rails-docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM ruby:3.2.2
+RUN apt-get update -qq && apt-get install -y build-essential libpq-dev nodejs
+RUN mkdir /rails-docker
+WORKDIR /rails-docker
+ADD Gemfile /rails-docker/Gemfile
+ADD Gemfile.lock /rails-docker/Gemfile.lock
+RUN bundle install
+ADD . /rails-docker

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -125,6 +125,8 @@ GEM
     net-smtp (0.3.3)
       net-protocol
     nio4r (2.5.9)
+    nokogiri (1.15.2-aarch64-linux)
+      racc (~> 1.4)
     nokogiri (1.15.2-x86_64-linux)
       racc (~> 1.4)
     pg (1.5.3)
@@ -208,6 +210,7 @@ GEM
     zeitwerk (2.6.8)
 
 PLATFORMS
+  aarch64-linux
   x86_64-linux
 
 DEPENDENCIES

--- a/config/database.yml
+++ b/config/database.yml
@@ -17,13 +17,15 @@
 default: &default
   adapter: postgresql
   encoding: unicode
+  host: db
+  username: postgres
+  password: postgres
+  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   # For details on connection pooling, see Rails configuration guide
   # https://guides.rubyonrails.org/configuring.html#database-pooling
-  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-
 development:
   <<: *default
-  database: myapp_development
+  database: postgres
 
   # The specified database role being used to connect to postgres.
   # To create additional roles in postgres see `$ createuser --help`.
@@ -57,7 +59,7 @@ development:
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: myapp_test
+  database: postgres
 
 # As with config/credentials.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is
@@ -81,6 +83,6 @@ test:
 #
 production:
   <<: *default
-  database: myapp_production
-  username: myapp
-  password: <%= ENV["MYAPP_DATABASE_PASSWORD"] %>
+  database: postgres
+  username: rails-docker
+  password: <%= ENV["RAILSDOCKER_DATABASE_PASSWORD"] %>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+ services:
+  db:
+    image: postgres:12
+    ports:
+      - "5432:5432"
+    environment:
+      - POSTGRES_PASSWORD=postgres
+  web:
+    build: .
+    command: bundle exec rails s -p 3000 -b '0.0.0.0'
+    volumes:
+      - .:/rails-docker
+    environment:
+      - POSTGRES_PASSWORD=postgres
+      - POSTGRES_DB=postgres
+    tty: true
+    stdin_open: true 
+    ports:
+      - "3000:3000"
+    depends_on:
+      - db


### PR DESCRIPTION
お疲れ様です。
Railsプロジェクトをdocker化しました。
また、READMEに環境構築方法記載しました。
ご確認よろしくお願いいたします。

<img width="1512" alt="スクリーンショット 2025-03-11 10 06 57" src="https://github.com/user-attachments/assets/3961e47a-d2bf-425c-8fc6-1cfab454f331" />


[+] Running 3/3
 ✔ Network rails-docker_default  Created                                                    0.1s 
 ✔ Container rails-docker-db-1   Created                                                    0.1s 
 ✔ Container rails-docker-web-1  Created                                                    0.1s 
Attaching to db-1, web-1
db-1   | The files belonging to this database system will be owned by user "postgres".
db-1   | This user must also own the server process.
db-1   | 
db-1   | The database cluster will be initialized with locale "en_US.utf8".
db-1   | The default database encoding has accordingly been set to "UTF8".
db-1   | The default text search configuration will be set to "english".
db-1   | 
db-1   | Data page checksums are disabled.
db-1   | 
db-1   | fixing permissions on existing directory /var/lib/postgresql/data ... ok
db-1   | creating subdirectories ... ok
db-1   | selecting dynamic shared memory implementation ... posix
db-1   | selecting default max_connections ... 100
db-1   | selecting default shared_buffers ... 128MB
db-1   | selecting default time zone ... Etc/UTC
db-1   | creating configuration files ... ok
db-1   | running bootstrap script ... ok
db-1   | performing post-bootstrap initialization ... ok
db-1   | syncing data to disk ... ok
db-1   | 
db-1   | 
db-1   | Success. You can now start the database server using:
db-1   | 
db-1   |     pg_ctl -D /var/lib/postgresql/data -l logfile start
db-1   | 
db-1   | initdb: warning: enabling "trust" authentication for local connections
db-1   | You can change this by editing pg_hba.conf or using the option -A, or
db-1   | --auth-local and --auth-host, the next time you run initdb.
db-1   | waiting for server to start....2025-03-11 00:03:21.548 UTC [47] LOG:  starting PostgreSQL 12.22 (Debian 12.22-1.pgdg120+1) on aarch64-unknown-linux-gnu, compiled by gcc (Debian 12.2.0-14) 12.2.0, 64-bit
db-1   | 2025-03-11 00:03:21.549 UTC [47] LOG:  listening on Unix socket "/var/run/postgresql/.s.PGSQL.5432"
db-1   | 2025-03-11 00:03:21.556 UTC [48] LOG:  database system was shut down at 2025-03-11 00:03:21 UTC
db-1   | 2025-03-11 00:03:21.558 UTC [47] LOG:  database system is ready to accept connections
db-1   |  done
db-1   | server started
db-1   | 
db-1   | /usr/local/bin/docker-entrypoint.sh: ignoring /docker-entrypoint-initdb.d/*
db-1   | 
db-1   | waiting for server to shut down....2025-03-11 00:03:21.681 UTC [47] LOG:  received fast shutdown request
db-1   | 2025-03-11 00:03:21.682 UTC [47] LOG:  aborting any active transactions
db-1   | 2025-03-11 00:03:21.683 UTC [47] LOG:  background worker "logical replication launcher" (PID 54) exited with exit code 1
db-1   | 2025-03-11 00:03:21.683 UTC [49] LOG:  shutting down
db-1   | 2025-03-11 00:03:21.690 UTC [47] LOG:  database system is shut down
db-1   |  done
db-1   | server stopped
db-1   | 
db-1   | PostgreSQL init process complete; ready for start up.
db-1   | 
db-1   | 2025-03-11 00:03:21.790 UTC [1] LOG:  starting PostgreSQL 12.22 (Debian 12.22-1.pgdg120+1) on aarch64-unknown-linux-gnu, compiled by gcc (Debian 12.2.0-14) 12.2.0, 64-bit
db-1   | 2025-03-11 00:03:21.790 UTC [1] LOG:  listening on IPv4 address "0.0.0.0", port 5432
db-1   | 2025-03-11 00:03:21.790 UTC [1] LOG:  listening on IPv6 address "::", port 5432
db-1   | 2025-03-11 00:03:21.791 UTC [1] LOG:  listening on Unix socket "/var/run/postgresql/.s.PGSQL.5432"
db-1   | 2025-03-11 00:03:21.796 UTC [67] LOG:  database system was shut down at 2025-03-11 00:03:21 UTC
db-1   | 2025-03-11 00:03:21.798 UTC [1] LOG:  database system is ready to accept connections
web-1  | => Booting Puma
web-1  | => Rails 7.0.6 application starting in development 
web-1  | => Run `bin/rails server --help` for more startup options
web-1  | Puma starting in single mode...
web-1  | * Puma version: 5.6.6 (ruby 3.2.2-p53) ("Birdie's Version")
web-1  | *  Min threads: 5
web-1  | *  Max threads: 5
web-1  | *  Environment: development
web-1  | *          PID: 1
web-1  | * Listening on http://0.0.0.0:3000
web-1  | Use Ctrl-C to stop
web-1  | Started GET "/" for 192.168.65.1 at 2025-03-11 00:03:22 +0000
web-1  | Cannot render console from 192.168.65.1! Allowed networks: 127.0.0.0/127.255.255.255, ::1
web-1  |    (2.5ms)  CREATE TABLE "schema_migrations" ("version" character varying NOT NULL PRIMARY KEY)
web-1  |    (1.5ms)  CREATE TABLE "ar_internal_metadata" ("key" character varying NOT NULL PRIMARY KEY, "value" character varying, "created_at" timestamp(6) NOT NULL, "updated_at" timestamp(6) NOT NULL)
web-1  |   ActiveRecord::SchemaMigration Pluck (0.1ms)  SELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC
web-1  |   
web-1  | ActiveRecord::PendingMigrationError (
web-1  | 
web-1  | Migrations are pending. To resolve this issue, run:
web-1  | 
web-1  |         bin/rails db:migrate RAILS_ENV=development
web-1  | 
web-1  | You have 1 pending migration:
web-1  | 
web-1  | 20230704042024_create_tasks.rb
web-1  | 
web-1  | 
web-1  | ):
web-1  |   
web-1  | activerecord (7.0.6) lib/active_record/migration.rb:627:in `check_pending!'
web-1  | activerecord (7.0.6) lib/active_record/migration.rb:592:in `block (2 levels) in call'
web-1  | activesupport (7.0.6) lib/active_support/file_update_checker.rb:83:in `execute'
web-1  | activerecord (7.0.6) lib/active_record/migration.rb:597:in `block in call'
web-1  | activerecord (7.0.6) lib/active_record/migration.rb:589:in `synchronize'
web-1  | activerecord (7.0.6) lib/active_record/migration.rb:589:in `call'
web-1  | actionpack (7.0.6) lib/action_dispatch/middleware/callbacks.rb:27:in `block in call'
web-1  | activesupport (7.0.6) lib/active_support/callbacks.rb:99:in `run_callbacks'
web-1  | actionpack (7.0.6) lib/action_dispatch/middleware/callbacks.rb:26:in `call'
web-1  | actionpack (7.0.6) lib/action_dispatch/middleware/executor.rb:14:in `call'
web-1  | actionpack (7.0.6) lib/action_dispatch/middleware/actionable_exceptions.rb:17:in `call'
web-1  | actionpack (7.0.6) lib/action_dispatch/middleware/debug_exceptions.rb:28:in `call'
web-1  | web-console (4.2.0) lib/web_console/middleware.rb:132:in `call_app'
web-1  | web-console (4.2.0) lib/web_console/middleware.rb:19:in `block in call'
web-1  | web-console (4.2.0) lib/web_console/middleware.rb:17:in `catch'
web-1  | web-console (4.2.0) lib/web_console/middleware.rb:17:in `call'
web-1  | actionpack (7.0.6) lib/action_dispatch/middleware/show_exceptions.rb:29:in `call'
web-1  | railties (7.0.6) lib/rails/rack/logger.rb:40:in `call_app'
web-1  | railties (7.0.6) lib/rails/rack/logger.rb:25:in `block in call'
web-1  | activesupport (7.0.6) lib/active_support/tagged_logging.rb:99:in `block in tagged'
web-1  | activesupport (7.0.6) lib/active_support/tagged_logging.rb:37:in `tagged'
web-1  | activesupport (7.0.6) lib/active_support/tagged_logging.rb:99:in `tagged'
web-1  | railties (7.0.6) lib/rails/rack/logger.rb:25:in `call'
web-1  | sprockets-rails (3.4.2) lib/sprockets/rails/quiet_assets.rb:13:in `call'
web-1  | actionpack (7.0.6) lib/action_dispatch/middleware/remote_ip.rb:93:in `call'
web-1  | actionpack (7.0.6) lib/action_dispatch/middleware/request_id.rb:26:in `call'
web-1  | rack (2.2.7) lib/rack/method_override.rb:24:in `call'
web-1  | rack (2.2.7) lib/rack/runtime.rb:22:in `call'
web-1  | activesupport (7.0.6) lib/active_support/cache/strategy/local_cache_middleware.rb:29:in `call'
web-1  | actionpack (7.0.6) lib/action_dispatch/middleware/server_timing.rb:61:in `block in call'
web-1  | actionpack (7.0.6) lib/action_dispatch/middleware/server_timing.rb:26:in `collect_events'
web-1  | actionpack (7.0.6) lib/action_dispatch/middleware/server_timing.rb:60:in `call'
web-1  | actionpack (7.0.6) lib/action_dispatch/middleware/executor.rb:14:in `call'
web-1  | actionpack (7.0.6) lib/action_dispatch/middleware/static.rb:23:in `call'
web-1  | rack (2.2.7) lib/rack/sendfile.rb:110:in `call'
web-1  | actionpack (7.0.6) lib/action_dispatch/middleware/host_authorization.rb:137:in `call'
web-1  | railties (7.0.6) lib/rails/engine.rb:530:in `call'
web-1  | puma (5.6.6) lib/puma/configuration.rb:252:in `call'
web-1  | puma (5.6.6) lib/puma/request.rb:77:in `block in handle_request'
web-1  | puma (5.6.6) lib/puma/thread_pool.rb:340:in `with_force_shutdown'
web-1  | puma (5.6.6) lib/puma/request.rb:76:in `handle_request'
web-1  | puma (5.6.6) lib/puma/server.rb:443:in `process_client'
web-1  | puma (5.6.6) lib/puma/thread_pool.rb:147:in `block in spawn_thread'
web-1  | Started GET "/" for 192.168.65.1 at 2025-03-11 00:04:54 +0000
web-1  | Cannot render console from 192.168.65.1! Allowed networks: 127.0.0.0/127.255.255.255, ::1
web-1  |   ActiveRecord::SchemaMigration Pluck (0.2ms)  SELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC
web-1  | Processing by TasksController#index as HTML
web-1  |   Rendering layout layouts/application.html.erb
web-1  |   Rendering tasks/index.html.erb within layouts/application
web-1  |   Task Load (0.4ms)  SELECT "tasks".* FROM "tasks"
web-1  |   ↳ app/views/tasks/index.html.erb:6
web-1  |   Rendered tasks/index.html.erb within layouts/application (Duration: 4.1ms | Allocations: 1497)
web-1  |   Rendered layout layouts/application.html.erb (Duration: 64.0ms | Allocations: 34465)
web-1  | Completed 200 OK in 71ms (Views: 64.8ms | ActiveRecord: 0.4ms | Allocations: 37264)
web-1  | 
web-1  | 
web-1  | Started GET "/" for 192.168.65.1 at 2025-03-11 00:05:43 +0000
web-1  | Cannot render console from 192.168.65.1! Allowed networks: 127.0.0.0/127.255.255.255, ::1
web-1  | Processing by TasksController#index as HTML
web-1  |   Rendering layout layouts/application.html.erb
web-1  |   Rendering tasks/index.html.erb within layouts/application
web-1  |   Task Load (1.2ms)  SELECT "tasks".* FROM "tasks"
web-1  |   ↳ app/views/tasks/index.html.erb:6
web-1  |   Rendered tasks/index.html.erb within layouts/application (Duration: 17.5ms | Allocations: 818)
web-1  |   Rendered layout layouts/application.html.erb (Duration: 31.1ms | Allocations: 2924)
web-1  | Completed 200 OK in 37ms (Views: 32.4ms | ActiveRecord: 1.2ms | Allocations: 3200)
web-1  | 
web-1  | 
web-1  | Started GET "/tasks" for 192.168.65.1 at 2025-03-11 00:05:47 +0000
web-1  | Cannot render console from 192.168.65.1! Allowed networks: 127.0.0.0/127.255.255.255, ::1
web-1  | Processing by TasksController#index as HTML
web-1  |   Rendering layout layouts/application.html.erb
web-1  |   Rendering tasks/index.html.erb within layouts/application
web-1  |   Task Load (0.5ms)  SELECT "tasks".* FROM "tasks"
web-1  |   ↳ app/views/tasks/index.html.erb:6
web-1  |   Rendered tasks/index.html.erb within layouts/application (Duration: 6.6ms | Allocations: 804)
web-1  |   Rendered layout layouts/application.html.erb (Duration: 10.9ms | Allocations: 2909)
web-1  | Completed 200 OK in 14ms (Views: 10.8ms | ActiveRecord: 0.5ms | Allocations: 3178)